### PR TITLE
Fixed integer division issue

### DIFF
--- a/LinkedInt.py
+++ b/LinkedInt.py
@@ -169,7 +169,7 @@ def get_search():
     data_total = content['elements'][0]['total']
 
     # Calculate pages off final results at 40 results/page
-    pages = data_total / 40
+    pages = int(math.ceil(data_total / 40.0))
 
     if pages == 0:
     	pages = 1


### PR DESCRIPTION
The final page of results was always omitted because integer division always rounds down, I converted the number of results to page to a float and rounded the result of the division up, then converted to an integer.