### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ beautifulsoup4==4.6.0
 certifi==2018.1.18
 chardet==3.0.4
 idna==2.6
-pkg-resources==0.0.0
 requests==2.18.4
 thready==0.1.5
 urllib3==1.22


### PR DESCRIPTION
fixes this issue 

Collecting pkg-resources==0.0.0 (from -r requirements.txt (line 5))
  ERROR: Could not find a version that satisfies the requirement pkg-resources==0.0.0 (from -r requirements.txt (line 5)) (from versions: none)
ERROR: No matching distribution found for pkg-resources==0.0.0 (from -r requirements.txt (line 5))