### PR TITLE
LinkedIn profile URL is not displayed properly if profile URL contains emoji

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 LinkedInt.cfg
+*.html
+*.csv

--- a/LinkedInt.cfg
+++ b/LinkedInt.cfg
@@ -1,7 +1,6 @@
 [API_KEYS]
-hunter = 
+hunter = ""
 
 [CREDS]
 linkedin_username = 
 linkedin_password = 
-

--- a/LinkedInt.py
+++ b/LinkedInt.py
@@ -223,7 +223,7 @@ def get_search():
                     data_picture = ""
 
                
-
+                data_slug = repr(data_slug.encode("utf-8")).replace("\\x","%").replace("b","",1).replace("'","")
                 parts = data_lastname.split()
 
                 name = data_firstname + " " + data_lastname
@@ -311,7 +311,7 @@ def get_search():
                 f.close()
                 f = open(baseDir + '{}.csv'.format(outfile), 'wb')
                 newcsv='\n'.join(csv)
-                f.writelines(newcsv.encode())
+                f.write(newcsv.encode())
                 for x in csv:
                     f.write(x.join('\n').encode())
                 f.close()

--- a/LinkedInt.py
+++ b/LinkedInt.py
@@ -332,7 +332,7 @@ def authenticate():
 
 if __name__ == '__main__':
     print("")
-    a = open(baseDir + "banner.txt","r")
+    a = open(baseDir + "banner.txt","r", encoding="utf-8")
     print(a.read())
     a.close()
     print("")


### PR DESCRIPTION
E.g. When you visit a profile url with emoji, the link is not displayed properly, 

![image](https://user-images.githubusercontent.com/7576046/120790593-bdb42280-c565-11eb-888a-be147e0aade2.png)


![image](https://user-images.githubusercontent.com/7576046/120790257-47afbb80-c565-11eb-881e-4bad5289e62f.png)

By encoding and the replacing the \x with % this solve the issue as shown below, 
repr(data_slug.encode("utf-8")).replace("\\x","%").replace("b","",1).replace("'","")

