### PR TITLE
removed versions so pip can resolve on its own

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ beautifulsoup4==4.6.0
 certifi==2018.1.18
 chardet==3.0.4
 idna==2.6
-requests==2.20.0
+requests
 thready==0.1.5
-urllib3==1.26.5
+urllib3
+


### PR DESCRIPTION
requests and urllib3 versions declaration causing conflicts

`ERROR: Cannot install -r requirements.txt (line 5) and urllib3==1.26.5 because these package versions have conflicting dependencies.`

`The conflict is caused by:
The user requested urllib3==1.26.5
requests 2.20.0 depends on urllib3<1.25 and >=1.21.1`

